### PR TITLE
Fix eslint and some compile error in linux

### DIFF
--- a/modules/routes.js
+++ b/modules/routes.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Route, IndexRoute } from 'react-router';
-import App from '../src/components/app';
+import App from '../src/components/App';
 import Home from '../src/components/Home';
 import Repos from '../src/components/Repos';
 import Repo from '../src/components/Repo';
-import About from '../src/components/about';
-import Hello from '../src/components/hello';
+import About from '../src/components/About';
+import Hello from '../src/components/Hello';
 
 module.exports = (
   <Route path="/" component={App}>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:client": "webpack",
     "build:server": "webpack --config webpack.server.config.js",
     "build": "npm run build:client && npm run build:server",
-    "lint:js": "eslint . --cache"
+    "lint": "eslint . --cache"
   },
   "author": "",
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,9 +14,6 @@ module.exports = {
         test: /\.js$/,
         enforce: 'pre',
         loader: 'eslint-loader',
-        options: {
-          emitWarning: true,
-        },
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
1. Simplify script name of linting.
2. Now linting error causes compile failure.
3. In linux, components' name in import should be matched with their file name, so capitalized.