### PR TITLE
Add session middleware to express

### DIFF
--- a/config/aws.config.devo.json
+++ b/config/aws.config.devo.json
@@ -4,5 +4,7 @@
   },
   "cognito": {
     "identity_pool_id": "us-west-2:23a18e5e-7934-4746-b5dc-f89da30095f1"
+  },
+  "dynamodb": {
   }
 }

--- a/config/aws.config.prod.json
+++ b/config/aws.config.prod.json
@@ -4,5 +4,8 @@
   },
   "cognito": {
     "identity_pool_id": "us-west-2:a850fbb8-2356-4a0f-af2d-97fb2574524b"
+  },
+  "dynamodb": {
+    "session": "arn:aws:dynamodb:us-west-2:960280041249:table/hello_session"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "dependencies": {
     "aws-sdk": "^2.49.0",
     "aws-serverless-express": "^2.1.3",
+    "connect-dynamodb": "^1.0.12",
     "express": "^4.14.1",
+    "express-session": "^1.15.5",
     "prop-types": "^15.5.9",
     "react": "^15.4.2",
     "react-bootstrap": "^0.30.7",

--- a/server/app.js
+++ b/server/app.js
@@ -16,7 +16,7 @@ import session from 'express-session';
 const store = createReduxStore({});
 
 const app = express();
-const DynamoDBStore = connectDynamoDb({session: session});
+const DynamoDBStore = connectDynamoDb({session});
 
 const sessionOption = {
   resave: false,
@@ -41,7 +41,7 @@ if (process.env.NODE_ENV === 'production') {
     writeCapacityUnits: 2,
   };
 
-  sessionOption['store'] = new DynamoDBStore(dynamoDBOptions);
+  sessionOption.store = new DynamoDBStore(dynamoDBOptions);
 } else {
   console.log('session will be stored in memory');
 }

--- a/server/app.js
+++ b/server/app.js
@@ -3,17 +3,50 @@
 var express = require('express');
 var path = require('path');
 
+import awsConfig from 'aws.config.json';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { match, RouterContext } from 'react-router';
 import routes from '../modules/routes';
 import { Provider } from 'react-redux';
+import connectDynamoDb from 'connect-dynamodb';
 import createReduxStore from '../modules/store';
+import session from 'express-session';
 
 const store = createReduxStore({});
 
 const app = express();
+const DynamoDBStore = connectDynamoDb({session: session});
 
+const sessionOption = {
+  resave: false,
+  saveUninitialized: true,
+  secret: 'session secret',
+};
+
+if (process.env.NODE_ENV === 'production') {
+  // Use DynamoDB only in production. Session will be stored in memory in non-production.
+
+  const dynamoDBOptions = {
+    // Optional DynamoDB table name, defaults to 'sessions'
+    table: 'hello_session',
+
+    // Optional JSON object of AWS credentials and configuration
+    AWSConfigJSON: {
+      region: awsConfig.common.region,
+    },
+
+    // Optional ProvisionedThroughput params, defaults to 5
+    readCapacityUnits: 2,
+    writeCapacityUnits: 2,
+  };
+
+  sessionOption['store'] = new DynamoDBStore(dynamoDBOptions);
+} else {
+  console.log('session will be stored in memory');
+}
+
+app.use(session(sessionOption));
 app.use(express.static(path.join(__dirname, './public')));
 
 app.get('*', (req, res) => {


### PR DESCRIPTION
https://github.com/ca98am79/connect-dynamodb

connect-dynamodb has been added to use dynamodb to store
session to dynamodb. Note that this is the case only in prod.
Session is stored in memory in non-production environment.